### PR TITLE
Update gemini thinking configuration and token usage tracking

### DIFF
--- a/slr_assessor/llm/providers.py
+++ b/slr_assessor/llm/providers.py
@@ -134,9 +134,8 @@ class GeminiProvider:
                     contents=prompt,
                     config=types.GenerateContentConfig(
                         temperature=0.1,
-                        max_output_tokens=1000,
                         thinking_config=types.ThinkingConfig(
-                            thinking_budget=0
+                            thinking_budget=-1
                         ),
                     ),
                 )
@@ -146,7 +145,6 @@ class GeminiProvider:
                     contents=prompt,
                     config=types.GenerateContentConfig(
                         temperature=0.1,
-                        max_output_tokens=1000
                     ),
                 )
 

--- a/slr_assessor/utils/cost_calculator.py
+++ b/slr_assessor/utils/cost_calculator.py
@@ -56,6 +56,11 @@ def estimate_tokens(text: str, model: str = "gpt-4") -> int:
         if model.startswith("gpt"):
             encoding = tiktoken.encoding_for_model(model)
             return len(encoding.encode(text))
+        elif model.startswith("gemini"):
+            # Gemini models use a different tokenizer
+            from google import genai
+            client = genai.Client()
+            return client.models.count_tokens(model=model, contents=text)
         else:
             # Rough estimation for non-OpenAI models (4 chars per token average)
             return len(text) // 4


### PR DESCRIPTION
This pull request introduces significant updates to the `GeminiProvider` and its associated utilities, focusing on improved token usage tracking, support for different Gemini models, and enhanced test coverage. Key changes include replacing estimated token calculations with actual token usage from the API, adding support for the Gemini 2.5 model with a "thinking config," and expanding test cases to cover various scenarios.

### Updates to Token Usage Calculation:
* Replaced estimated token calculations with actual token usage data from the Gemini API, including support for additional token count fields like `thoughts_token_count` and `tool_use_prompt_token_count` (`slr_assessor/llm/providers.py`, [slr_assessor/llm/providers.pyL149-R164](diffhunk://#diff-3e9507e8ed52a59f7ad8687bda78b751ead2b88dd6fbf4cd18587fbb2a86294cL149-R164)).
* Updated the `estimate_tokens` utility to handle Gemini models using their specific tokenizer via the `google.genai` library (`slr_assessor/utils/cost_calculator.py`, [slr_assessor/utils/cost_calculator.pyR59-R63](diffhunk://#diff-eca7ece65ea913eed96d514708caf4c1bcb7ec55193ac93be1c863a7859518afR59-R63)).

### Support for Gemini 2.5 Model:
* Introduced support for the Gemini 2.5 model, which uses a "thinking config" with a `thinking_budget` of `-1` (`slr_assessor/llm/providers.py`, [slr_assessor/llm/providers.pyL137-R138](diffhunk://#diff-3e9507e8ed52a59f7ad8687bda78b751ead2b88dd6fbf4cd18587fbb2a86294cL137-R138)).

### Expanded Test Coverage:
* Added new test cases to validate behavior for different Gemini models, including Gemini 2.5 with "thinking config" and regular models without it (`tests/test_providers.py`, [tests/test_providers.pyR213-R360](diffhunk://#diff-864023bf5f9f833678b86d78cf8354385edaf4439d52876ab6b819bfe58d8c35R213-R360)).
* Implemented tests for handling API errors and cost calculation failures to ensure robustness in edge cases (`tests/test_providers.py`, [tests/test_providers.pyR213-R360](diffhunk://#diff-864023bf5f9f833678b86d78cf8354385edaf4439d52876ab6b819bfe58d8c35R213-R360)).